### PR TITLE
Configured Travis to run tests on Linux 🐧

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,9 @@ init:
   - git config --global core.autocrlf input
 
 install:
+  # Install code linting tools.
+  - go get -u golang.org/x/lint/golint
+    # Configure Cygwin, which can run Makefiles.
   - set PATH=C:\cygwin\bin;%PATH%
   - echo %GOPATH%
   - go version
@@ -27,4 +30,4 @@ install:
 build: off
 deploy: off
 
-test_script: make test-race-v
+test_script: make review-race-v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,26 @@ git:
 
 os:
   - osx
+  - linux
 
-## Testing configuration
+## Install dependencies and code review tools
 before_install:
-  # - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+  # Required for auto-linting Go code.
   - go get -u golang.org/x/lint/golint
+    # Required for tests on Linux.
+  - if [ "$TRAVIS_OS_NAME" == "linux" ];
+    then sudo apt-get install xclip;
+    fi
 
-install: go get -t ./...
+install:
+  # Install all sub-packages; include tests.
+  - go get -t ./...
 
-script: make review-race-v
+script: |
+  if [ "$TRAVIS_OS_NAME" == "osx" ];
+  then make review-race-v;
+  else xvfb-run make review-race-v; # Imitate an display on Linux
+  fi
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Last time I tried configuring Linux tests, I was stumped by the need to have an X-server up and running on Travis. Turns out what I was looking for was `xvfb-run`!

_Used this for reference:_ https://docs.travis-ci.com/user/gui-and-headless-browsers/